### PR TITLE
Make Scripts OS Agnostic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3,6 +3,9 @@
   "workspaces": {
     "": {
       "name": "Tales Beyond",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+      },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "bootstrap": "^5.3.6",
@@ -141,7 +144,7 @@
 
     "addons-scanner-utils": ["addons-scanner-utils@9.12.0", "", { "dependencies": { "@types/yauzl": "2.10.3", "common-tags": "1.8.2", "first-chunk-stream": "3.0.0", "strip-bom-stream": "4.0.0", "upath": "2.0.1", "yauzl": "2.10.0" }, "peerDependencies": { "body-parser": "1.20.3", "express": "4.21.0", "node-fetch": "2.6.11", "safe-compare": "1.1.4" }, "optionalPeers": ["body-parser", "express", "node-fetch", "safe-compare"] }, "sha512-Nn+mOgJhdSZKkycXd5GYfSfoyT1lEGbCVoCBKriEFceuP0dJxVBuFwuRD8+PuXegQQBw7COTS5DwM4nj+bK8Mg=="],
 
-    "adm-zip": ["adm-zip@0.5.12", "", {}, "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ=="],
+    "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
 
     "agent-base": ["agent-base@7.1.3", "", {}, "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="],
 
@@ -846,6 +849,8 @@
     "eslint/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "eslint/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "firefox-profile/adm-zip": ["adm-zip@0.5.12", "", {}, "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ=="],
 
     "fx-runner/commander": ["commander@2.9.0", "", { "dependencies": { "graceful-readlink": ">= 1.0.0" } }, "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A=="],
 

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "marked": "^15.0.11",
     "sass": "^1.88.0",
     "web-ext": "8.6.0"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.16"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -61,7 +61,11 @@ const bunBuild = async (config) => {
 
 const buildShared = async () => {
   await fs.mkdir(sharedDir, { recursive: true });
-  await $`cp -rf ${srcDir}/{icons,options.html} LICENSE README.md CHANGELOG.md ${sharedDir}`;
+  await fs.cp(path.join(srcDir, "icons"), path.join(sharedDir, "icons"), { recursive: true });
+  await fs.copyFile(path.join(srcDir, "options.html"), path.join(sharedDir, "options.html"));
+  await fs.copyFile("LICENSE", path.join(sharedDir, "LICENSE"));
+  await fs.copyFile("README.md", path.join(sharedDir, "README.md"));
+  await fs.copyFile("CHANGELOG.md", path.join(sharedDir, "CHANGELOG.md"));
 };
 
 const buildBrowser = async () => {
@@ -90,7 +94,7 @@ const buildBrowser = async () => {
     });
   }
 
-  await $`cp -rf ${browserSrcDir}/background.js ${sharedBrowserDir}`;
+  await fs.copyFile(path.join(browserSrcDir, "background.js"), path.join(sharedBrowserDir, "background.js"));
 
   for (const browser of browsers) {
     const buildDir = path.join(process.cwd(), "build", browser);
@@ -157,7 +161,7 @@ const buildSymbiote = async () => {
     recursive: true,
   });
 
-  await $`cp -rf ${symbioteSrcDir}/index.html ${buildDir}`;
+  await fs.copyFile(path.join(symbioteSrcDir, "index.html"), path.join(buildDir, "index.html"));
 
   // Manifest
   const manifest = { version, ...manifestBase };

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -3,7 +3,9 @@
 // Creates chrome and symbiote zips
 
 import path from "node:path";
+import fs from "node:fs/promises";
 import Bun, { $ } from "bun";
+import AdmZip from "adm-zip";
 
 await $`bun web-ext build -o -s build/chrome`;
 
@@ -13,6 +15,15 @@ const { version } = await Bun.file(
 
 const symbioteZip = `web-ext-artifacts/tales-beyond-symbiote-${version}.zip`;
 
-await $`rm -f ${symbioteZip}`;
-await $`7z a ${symbioteZip} ./build/symbiote/`;
-await $`7z rn ${symbioteZip} symbiote tales-beyond`;
+try {
+    await fs.unlink(symbioteZip);
+} catch (err) {
+    if (err.code !== "ENOENT") throw err;
+}
+
+const zip = new AdmZip();
+zip.addLocalFolder("./build/symbiote", "tales-beyond");
+
+await fs.mkdir("web-ext-artifacts", { recursive: true });
+
+zip.writeZip(symbioteZip);


### PR DESCRIPTION
I use a windows development environment without 7z. Wanted to make the scripts less dependent on environment. If you don't want this, I'll just keep the changes for my local stuff and work to not include these on future PRs.